### PR TITLE
Fix redirect URL

### DIFF
--- a/internal/auth.go
+++ b/internal/auth.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -93,11 +92,7 @@ func redirectBase(r *http.Request) string {
 func GetUriPath(r *http.Request) string {
 	prefix := r.Header.Get("X-Forwarded-Prefix")
 	uri := r.Header.Get("X-Forwarded-Uri")
-	p := path.Join(prefix, uri)
-	if strings.HasSuffix(uri, "/") {
-		p += "/"
-	}
-	return p
+	return fmt.Sprintf("%s/%s", strings.TrimRight(prefix, "/"), strings.TrimLeft(uri, "/"))
 }
 
 // // Return url


### PR DESCRIPTION
Fixes #3 

Path.Join shall not be used to join URLs, as it remove double slashes, (https://stackoverflow.com/questions/34668012/combine-url-paths-with-path-join)

The state query parameter, containing the redirect url is affected by this undesired behavior and it break Safari support