### PR TITLE
group claim support

### DIFF
--- a/internal/auth.go
+++ b/internal/auth.go
@@ -16,42 +16,55 @@ import (
 
 // Request Validation
 
-// Cookie = hash(secret, cookie domain, email, expires)|expires|email
-func ValidateCookie(r *http.Request, c *http.Cookie) (string, string, error) {
+// cookieClaims are extracted from the authorization cookie
+type cookieClaims struct {
+	email string
+	groups []string
+}
+
+// Cookie = hash(secret, cookie domain, email, expires)|expires|email|groups
+func ValidateCookie(r *http.Request, c *http.Cookie) (*cookieClaims, error) {
+	claims := cookieClaims{}
 	parts := strings.Split(c.Value, "|")
 
 	if len(parts) != 4 {
-		return "", "", errors.New("invalid cookie format")
+		return nil, errors.New("invalid cookie format")
 	}
 
 	mac, err := base64.URLEncoding.DecodeString(parts[0])
 	if err != nil {
-		return "", "", errors.New("unable to decode cookie mac")
+		return nil, errors.New("unable to decode cookie mac")
 	}
 
 	expectedSignature := cookieSignature(r, parts[2], parts[3], parts[1])
 	expected, err := base64.URLEncoding.DecodeString(expectedSignature)
 	if err != nil {
-		return "", "", errors.New("unable to generate mac")
+		return nil, errors.New("unable to generate mac")
 	}
 
 	// Valid token?
 	if !hmac.Equal(mac, expected) {
-		return "", "", errors.New("invalid cookie mac")
+		return nil, errors.New("invalid cookie mac")
 	}
 
 	expires, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return "", "", errors.New("unable to parse cookie expiry")
+		return nil, errors.New("unable to parse cookie expiry")
 	}
 
 	// Has it expired?
 	if time.Unix(expires, 0).Before(time.Now()) {
-		return "", "", errors.New("cookie has expired")
+		return nil, errors.New("cookie has expired")
 	}
+	claims.email = parts[2]
 
+	if len(parts[3]) > 0 {
+		for _, group := range strings.Split(parts[3], ",") {
+			claims.groups = append(claims.groups, group)
+		}
+	}
 	// Looks valid
-	return parts[2], parts[3], nil
+	return &claims, nil
 }
 
 // Validate email

--- a/internal/config.go
+++ b/internal/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	EnableImpersonation     bool                 `long:"enable-impersonation" env:"ENABLE_IMPERSONATION" description:"Indicates that impersonation headers should be set on successful auth"`
 	ServiceAccountTokenPath string               `long:"service-account-token-path" env:"SERVICE_ACCOUNT_TOKEN_PATH" default:"/var/run/secrets/kubernetes.io/serviceaccount/token" description:"When impersonation is enabled, this token is passed via the Authorization header to the ingress. The user associated with the token must have impersonation privileges."`
 	Rules                   map[string]*Rule     `long:"rules.<name>.<param>" description:"Rule definitions, param can be: \"action\" or \"rule\""`
+	GroupClaimPrefix        string               `long:"group-claim-prefix" env:"GROUP_CLAIM_PREFIX" default:"odic:" description:"prefix oidc group claims with this value"`
 
 	// Filled during transformations
 	OIDCContext         context.Context

--- a/internal/config.go
+++ b/internal/config.go
@@ -45,7 +45,7 @@ type Config struct {
 	EnableImpersonation     bool                 `long:"enable-impersonation" env:"ENABLE_IMPERSONATION" description:"Indicates that impersonation headers should be set on successful auth"`
 	ServiceAccountTokenPath string               `long:"service-account-token-path" env:"SERVICE_ACCOUNT_TOKEN_PATH" default:"/var/run/secrets/kubernetes.io/serviceaccount/token" description:"When impersonation is enabled, this token is passed via the Authorization header to the ingress. The user associated with the token must have impersonation privileges."`
 	Rules                   map[string]*Rule     `long:"rules.<name>.<param>" description:"Rule definitions, param can be: \"action\" or \"rule\""`
-	GroupClaimPrefix        string               `long:"group-claim-prefix" env:"GROUP_CLAIM_PREFIX" default:"odic:" description:"prefix oidc group claims with this value"`
+	GroupClaimPrefix        string               `long:"group-claim-prefix" env:"GROUP_CLAIM_PREFIX" default:"oidc:" description:"prefix oidc group claims with this value"`
 
 	// Filled during transformations
 	OIDCContext         context.Context


### PR DESCRIPTION
Adds group claim support to TFA. When impersonation is enabled, the system:authenticated group will be added to the Impersonate-Group header. In addition, any OIDC group claims will be appended to the list and prefixed with `oidc:` (by default) to avoid conflict with system groups and also conform to the oidc-proxy implementation. 