### PR TITLE
store group claims in a session

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/go-kit/kit v0.8.0 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/sessions v1.2.0
 	github.com/gravitational/trace v0.0.0-20190409171327-f30095ced5ff // indirect
 	github.com/jonboulle/clockwork v0.1.0 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,10 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
+github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
+github.com/gorilla/sessions v1.2.0 h1:S7P+1Hm5V/AT9cjEcUD5uDaQSX0OE577aCXgoaKpYbQ=
+github.com/gorilla/sessions v1.2.0/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/gravitational/trace v0.0.0-20190409171327-f30095ced5ff h1:xL/fJdlTJL6R/6Qk2tPu3EP1NsXgap9hXLvxKH0Ytko=
 github.com/gravitational/trace v0.0.0-20190409171327-f30095ced5ff/go.mod h1:RvdOUHE4SHqR3oXlFFKnGzms8a5dugHygGw1bqDstYI=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=

--- a/internal/auth.go
+++ b/internal/auth.go
@@ -16,55 +16,42 @@ import (
 
 // Request Validation
 
-// cookieClaims are extracted from the authorization cookie
-type cookieClaims struct {
-	email string
-	groups []string
-}
-
 // Cookie = hash(secret, cookie domain, email, expires)|expires|email|groups
-func ValidateCookie(r *http.Request, c *http.Cookie) (*cookieClaims, error) {
-	claims := cookieClaims{}
+func ValidateCookie(r *http.Request, c *http.Cookie) (string, error) {
 	parts := strings.Split(c.Value, "|")
 
-	if len(parts) != 4 {
-		return nil, errors.New("invalid cookie format")
+	if len(parts) != 3 {
+		return "", errors.New("invalid cookie format")
 	}
 
 	mac, err := base64.URLEncoding.DecodeString(parts[0])
 	if err != nil {
-		return nil, errors.New("unable to decode cookie mac")
+		return "", errors.New("unable to decode cookie mac")
 	}
 
-	expectedSignature := cookieSignature(r, parts[2], parts[3], parts[1])
+	expectedSignature := cookieSignature(r, parts[2], parts[1])
 	expected, err := base64.URLEncoding.DecodeString(expectedSignature)
 	if err != nil {
-		return nil, errors.New("unable to generate mac")
+		return "", errors.New("unable to generate mac")
 	}
 
 	// Valid token?
 	if !hmac.Equal(mac, expected) {
-		return nil, errors.New("invalid cookie mac")
+		return "", errors.New("invalid cookie mac")
 	}
 
 	expires, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return nil, errors.New("unable to parse cookie expiry")
+		return "", errors.New("unable to parse cookie expiry")
 	}
 
 	// Has it expired?
 	if time.Unix(expires, 0).Before(time.Now()) {
-		return nil, errors.New("cookie has expired")
+		return "", errors.New("cookie has expired")
 	}
-	claims.email = parts[2]
 
-	if len(parts[3]) > 0 {
-		for _, group := range strings.Split(parts[3], ",") {
-			claims.groups = append(claims.groups, group)
-		}
-	}
 	// Looks valid
-	return &claims, nil
+	return parts[2], nil
 }
 
 // Validate email
@@ -147,11 +134,10 @@ func useAuthDomain(r *http.Request) (bool, string) {
 // Cookie methods
 
 // Create an auth cookie
-func MakeIDCookie(r *http.Request, email string, groups []string) *http.Cookie {
+func MakeIDCookie(r *http.Request, email string) *http.Cookie {
 	expires := cookieExpiry()
-	prefixedGroups := prefixAndJoinGroupClaims(groups)
-	mac := cookieSignature(r, email, prefixedGroups, fmt.Sprintf("%d", expires.Unix()))
-	value := fmt.Sprintf("%s|%d|%s|%s", mac, expires.Unix(), email, prefixedGroups)
+	mac := cookieSignature(r, email, fmt.Sprintf("%d", expires.Unix()))
+	value := fmt.Sprintf("%s|%d|%s", mac, expires.Unix(), email)
 
 	return &http.Cookie{
 		Name:     config.CookieName,
@@ -275,11 +261,10 @@ func matchCookieDomains(domain string) (bool, string) {
 }
 
 // Create cookie hmac
-func cookieSignature(r *http.Request, email, groups, expires string) string {
+func cookieSignature(r *http.Request, email, expires string) string {
 	hash := hmac.New(sha256.New, config.Secret)
 	hash.Write([]byte(cookieDomain(r)))
 	hash.Write([]byte(email))
-	hash.Write([]byte(groups))
 	hash.Write([]byte(expires))
 	return base64.URLEncoding.EncodeToString(hash.Sum(nil))
 }
@@ -351,13 +336,4 @@ func (c *CookieDomains) MarshalFlag() (string, error) {
 		domains = append(domains, d.Domain)
 	}
 	return strings.Join(domains, ","), nil
-}
-
-func prefixAndJoinGroupClaims(groups []string) string {
-	// system:authenticated group is applied to all authenticated users
-	t := []string{"system:authenticated"}
-	for _, group := range groups {
-		t = append(t, fmt.Sprintf("%s%s", config.GroupClaimPrefix, group))
-	}
-	return strings.Join(t, ",")
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	ServiceAccountTokenPath string               `long:"service-account-token-path" env:"SERVICE_ACCOUNT_TOKEN_PATH" default:"/var/run/secrets/kubernetes.io/serviceaccount/token" description:"When impersonation is enabled, this token is passed via the Authorization header to the ingress. The user associated with the token must have impersonation privileges."`
 	Rules                   map[string]*Rule     `long:"rules.<name>.<param>" description:"Rule definitions, param can be: \"action\" or \"rule\""`
 	GroupClaimPrefix        string               `long:"group-claim-prefix" env:"GROUP_CLAIM_PREFIX" default:"oidc:" description:"prefix oidc group claims with this value"`
+	SessionKey              string               `long:"session-key" env:"SESSION_KEY" description:"A session key used to encrypt browser sessions"`
 
 	// Filled during transformations
 	OIDCContext         context.Context

--- a/internal/server.go
+++ b/internal/server.go
@@ -3,11 +3,12 @@ package tfa
 import (
 	"fmt"
 	"net/http"
-	"net/url"
+	neturl "net/url"
 	"strings"
 
 	"github.com/containous/traefik/pkg/rules"
 	"github.com/coreos/go-oidc"
+	"github.com/gorilla/sessions"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 )
@@ -15,15 +16,18 @@ import (
 const (
 	impersonateUserHeader  = "Impersonate-User"
 	impersonateGroupHeader = "Impersonate-Group"
+	sessionName            = "group-claims-session"
 )
 
 type Server struct {
-	router *rules.Router
+	router       *rules.Router
+	sessionStore *sessions.CookieStore
 }
 
 func NewServer() *Server {
 	s := &Server{}
 	s.buildRoutes()
+	s.sessionStore = sessions.NewCookieStore([]byte(config.SessionKey))
 	return s
 }
 
@@ -36,10 +40,14 @@ func (s *Server) buildRoutes() {
 
 	// Let's build a router
 	for name, rule := range config.Rules {
+		var err error
 		if rule.Action == "allow" {
-			s.router.AddRoute(rule.formattedRule(), 1, s.AllowHandler(name))
+			err = s.router.AddRoute(rule.formattedRule(), 1, s.AllowHandler(name))
 		} else {
-			s.router.AddRoute(rule.formattedRule(), 1, s.AuthHandler(name))
+			err = s.router.AddRoute(rule.formattedRule(), 1, s.AuthHandler(name))
+		}
+		if err != nil {
+			panic(fmt.Sprintf("could not add route: %v", err))
 		}
 	}
 
@@ -66,7 +74,7 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 	// Modify request
 	r.Method = r.Header.Get("X-Forwarded-Method")
 	r.Host = r.Header.Get("X-Forwarded-Host")
-	r.URL, _ = url.Parse(GetUriPath(r))
+	r.URL, _ = neturl.Parse(GetUriPath(r))
 
 	if config.AuthHost == "" || len(config.CookieDomains) > 0 || r.Host == config.AuthHost {
 		s.router.ServeHTTP(w, r)
@@ -103,7 +111,7 @@ func (s *Server) AuthHandler(rule string) http.HandlerFunc {
 		}
 
 		// Validate cookie
-		claims, err := ValidateCookie(r, c)
+		email, err := ValidateCookie(r, c)
 		if err != nil {
 			if err.Error() == "Cookie has expired" {
 				logger.Info("Cookie has expired")
@@ -116,28 +124,34 @@ func (s *Server) AuthHandler(rule string) http.HandlerFunc {
 		}
 
 		// Validate user
-		valid := ValidateEmail(claims.email)
+		valid := ValidateEmail(email)
 		if !valid {
 			logger.WithFields(logrus.Fields{
-				"email": claims.email,
+				"email": email,
 			}).Errorf("Invalid email")
 			http.Error(w, "Not authorized", 401)
 			return
 		}
 
 		// Valid request
-		logger.Debugf("Allow request from %s", claims.email)
-		w.Header().Set("X-Forwarded-User", claims.email)
+		logger.Debugf("Allow request from %s", email)
+		w.Header().Set("X-Forwarded-User", email)
 
 		if config.EnableImpersonation {
-			// Set impersonation headers
-			logger.Debug(fmt.Sprintf("setting authorization token and impersonation headers: email: %s, groups: %s", claims.email, claims.groups))
-			w.Header().Set("Authorization", fmt.Sprintf("Bearer %s", config.ServiceAccountToken))
-			w.Header().Set(impersonateUserHeader, claims.email)
-			for _, group := range claims.groups {
-				w.Header().Set(impersonateGroupHeader, group)
+			groups, err := s.getGroupsFromSession(r)
+			if err != nil {
+				logger.Errorf("error getting groups from session: %w", err)
+				http.Error(w, "Bad Gateway", 502)
 			}
 
+			// Set impersonation headers
+			logger.Debug(fmt.Sprintf("setting authorization token and impersonation headers: email: %s, groups: %s", email, groups))
+			w.Header().Set("Authorization", fmt.Sprintf("Bearer %s", config.ServiceAccountToken))
+			w.Header().Set(impersonateUserHeader, email)
+			w.Header().Set(impersonateGroupHeader, "system:authenticated")
+			for _, group := range groups {
+				w.Header().Set(impersonateGroupHeader, group)
+			}
 		}
 		w.WriteHeader(200)
 	}
@@ -175,7 +189,7 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 			ClientSecret: config.ClientSecret,
 			RedirectURL:  redirectUri(r),
 			Endpoint:     provider.Endpoint(),
-			Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
+			Scopes:       []string{oidc.ScopeOpenID, "profile", "email", "groups"},
 		}
 
 		// Exchange code for token
@@ -217,7 +231,7 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 		}
 
 		// Generate cookies
-		http.SetCookie(w, MakeIDCookie(r, claims.Email, claims.Groups))
+		http.SetCookie(w, MakeIDCookie(r, claims.Email))
 		logger.WithFields(logrus.Fields{
 			"user": claims.Email,
 		}).Infof("Generated auth cookie")
@@ -233,6 +247,21 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 			"name": claims.Name,
 		}).Infof("Generated name cookie")
 
+		if len(claims.Groups) > 0 {
+			logger.Printf("creating group claims session with groups: %v", claims.Groups)
+			session, err := s.sessionStore.Get(r, sessionName)
+			if err != nil {
+				logger.Errorf("failed to get group claims session: %v", err)
+				http.Error(w, "Bad Gateway", 502)
+				return
+			}
+			session.Values["groups"] = make([]string, len(claims.Groups))
+			copy(session.Values["groups"].([]string), claims.Groups)
+			if err := session.Save(r, w); err != nil {
+				logger.Errorf("error saving session: %v", err)
+				http.Error(w, "Bad Gateway", 502)
+			}
+		}
 		// Redirect
 		http.Redirect(w, r, redirect, http.StatusTemporaryRedirect)
 	}
@@ -294,4 +323,22 @@ func (s *Server) logger(r *http.Request, rule, msg string) *logrus.Entry {
 	}).Debug(msg)
 
 	return logger
+}
+
+func (s *Server) getGroupsFromSession(r *http.Request) ([]string, error) {
+	session, err := s.sessionStore.Get(r, sessionName)
+	if err != nil {
+		return nil, fmt.Errorf("error getting session: %w", err)
+	}
+
+	i, ok := session.Values["groups"]
+	if !ok {
+		return make([]string, 0), nil
+	}
+
+	groups, ok := i.([]string)
+	if !ok {
+		return nil, fmt.Errorf("could not cast groups to string slice: %v", groups)
+	}
+	return groups, nil
 }


### PR DESCRIPTION
Group claims are now stored in a session cookie. This session uses the default storage backend provided by gorrilla, filesystem. This introduces some challenges regarding state which is handled by checking the existence of session, and re-authenticating if the auth cookie is valid, but the groups session does not exist. 

charts ref: https://github.com/mesosphere/charts/pull/331