### PR TITLE
Make possible to pass GROUPS_ATTRIBUTE_NAME to cover more providers.

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	Rules                   map[string]*Rule     `long:"rules.<name>.<param>" description:"Rule definitions, param can be: \"action\" or \"rule\""`
 	GroupClaimPrefix        string               `long:"group-claim-prefix" env:"GROUP_CLAIM_PREFIX" default:"oidc:" description:"prefix oidc group claims with this value"`
 	SessionKey              string               `long:"session-key" env:"SESSION_KEY" description:"A session key used to encrypt browser sessions"`
+	GroupsAttributeName     string               `long:"groups-attribute-name" env:"GROUPS_ATTRIBUTE_NAME" default:"groups" description:"Map the correct attribute that contain the user groups"`
 
 	// Filled during transformations
 	OIDCContext         context.Context


### PR DESCRIPTION
This parameter allows us to map the correct attribute that contains the user groups.
Example: In AWS Congito we have GROUPS_ATTRIBUTE_NAME="cognito:groups"

#14 