### PR TITLE
check if claims["name"] does not exist

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -284,9 +284,9 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 			logger.Errorf("failed to get email claims session")
 		}
 
-		// If name is empty or whitespace, use email address for name
+		// If name in null, empty or whitespace, use email address for name
 		name, ok := claims["name"]
-		if ok && strings.TrimSpace(name.(string)) == "" {
+		if !ok || (ok && strings.TrimSpace(name.(string)) == "") {
 			name = email.(string)
 		}
 


### PR DESCRIPTION
currently the code just checks for empty or whitespace only. 

If the claim is not set (e.g. when using keycloak with default configuration) the application tries to cast nil to a string in line 293.