### PR TITLE
[D2IQ-63391] improve error logging for provider failures

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -234,7 +234,7 @@ func (c *Config) SetOidcProvider() {
 	c.OIDCContext = context.Background()
 	provider, err := oidc.NewProvider(c.OIDCContext, c.ProviderUri)
 	if err != nil {
-		log.Fatal("failed to get provider configuration: %v", err)
+		log.Fatal("failed to get provider configuration for %s: %v (hint: make sure %s is accessible from the cluster)", c.ProviderUri, err, c.ProviderUri)
 	}
 	c.OIDCProvider = provider
 }


### PR DESCRIPTION
The purpose of this PR is to improve the actionability of the error that can occur when the requested OIDC provider configuration can _not_ be properly determined.

This resolves [D2IQ-63391](https://jira.d2iq.com/browse/D2IQ-63391).
