### PR TITLE
[1st & important] Fix domains and encryption key setup of securecookies with claims

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -201,6 +201,8 @@ func (c *Config) Validate() {
 	// Check for show stopper errors
 	if len(c.SecretString) == 0 {
 		log.Fatal("\"secret\" option must be set.")
+	} else if len(c.SecretString) < 32 {
+		log.Infoln("for better security, \"secret\" should ideally be 32 bytes or longer")
 	}
 
 	if c.ProviderUri == "" || c.ClientId == "" || c.ClientSecret == "" {
@@ -226,6 +228,13 @@ func (c *Config) Validate() {
 			log.Fatalf("impersonation is enabled, but failed to read %s : %v", c.ServiceAccountTokenPath, err)
 		}
 		c.ServiceAccountToken = strings.TrimSuffix(string(t), "\n")
+	}
+
+	// RBAC
+	if c.EnableRBAC && len(c.SessionKey) != 16 && len(c.SessionKey) != 24 && len(c.SessionKey) != 32 {
+		// Gorilla sessions require encryption keys of specific length
+		// https://www.gorillatoolkit.org/pkg/sessions#NewCookieStore
+		log.Fatal("\"session-key\" must be 16, 24 or 32 bytes long to select AES-128, AES-192, or AES-256 modes")
 	}
 }
 


### PR DESCRIPTION
Mainly fixes #23, fixes #25 by configuring Domains and other options of session store.

Additionally, enabling RBAC previously required `SESSION_KEY` to be set to a non-empty value. Enabling RBAC and not setting `SESSION_KEY` were silently ignored, resulting with no group claims cookie produced - effectively a **bug**.

Next, `SESSION_KEY` was documented as `A session key used to encrypt browser sessions` which was not true. Gorilla's [NewCookieStore](https://www.gorillatoolkit.org/pkg/sessions#NewCookieStore) says that the argument is a key or pair of keys. If only one key is passed, that is considered as only having the first key from the pair set, with the second key being empty. Keys are set in pairs because the first one of them is `authentication key` and the optional second one is `encryption key`. Multiple pairs can be set to allow key rotation. So the original implementation just setting the `SESSION_KEY` was actually setting it as the `authentication key`, preventing cookie value to be altered by a malicious actor, not encrypting the cookie as the config documentation string said - another **bug**.

This commit changes the behavior so that `SECRET` is used for authentication and `SESSION_KEY` is used for encryption as originally documented.

**Idea to discuss**: It would be possible to completely remove `SESSION_KEY` config field and use a single-key `SECRET` argument to `NewCookieStore` without encrypting the claims cookie. In the reality there is nothing secret in the groups claim so encryption is not really necessary. But having it encrypted (and using the pull request as-is) could allow more data (private eventually) to be stored in the session store.

**all tests are ok as before (I intentionally left the %w bug there as #27 fixes this)**