### PR TITLE
[2nd; optional, recommended] Minor changes, documentations, cleaning, case-insensitive RBAC subjects

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -24,7 +24,9 @@ func main() {
 	config.Validate()
 
 	// Query the OIDC provider
-	config.SetOidcProvider()
+	if err := config.LoadOIDCProviderConfiguration(); err != nil {
+		log.Fatalln(err.Error())
+	}
 
 	// Get clientset for Authorizers
 	var clientset kubernetes.Interface
@@ -37,8 +39,6 @@ func main() {
 		if err != nil {
 			log.Fatalf("error getting kubernetes client: %v", err)
 		}
-	} else {
-		clientset = nil
 	}
 
 	// Prepare cookie session store (first key is for auth, the second one for encryption)
@@ -54,7 +54,7 @@ func main() {
 	http.HandleFunc("/", server.RootHandler)
 
 	// Start
-	log.Debugf("Starting with options: %s", config)
-	log.Info("Listening on :4181")
+	log.Debugf("starting with options: %s", config)
+	log.Info("listening on :4181")
 	log.Info(http.ListenAndServe(":4181", nil))
 }

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -22,40 +22,40 @@ func TestAuthValidateCookie(t *testing.T) {
 
 	// Should require 3 parts
 	c.Value = ""
-	_, err := ValidateCookie(r, c)
+	_, err := validateCookie(r, c)
 	if assert.Error(err) {
 		assert.Equal("invalid cookie format", err.Error())
 	}
 	c.Value = "1|2"
-	_, err = ValidateCookie(r, c)
+	_, err = validateCookie(r, c)
 	if assert.Error(err) {
 		assert.Equal("invalid cookie format", err.Error())
 	}
 	c.Value = "1|2|3|4"
-	_, err = ValidateCookie(r, c)
+	_, err = validateCookie(r, c)
 	if assert.Error(err) {
 		assert.Equal("invalid cookie format", err.Error())
 	}
 
 	// Should catch invalid mac
 	c.Value = "MQ==|2|3"
-	_, err = ValidateCookie(r, c)
+	_, err = validateCookie(r, c)
 	if assert.Error(err) {
 		assert.Equal("invalid cookie mac", err.Error())
 	}
 
 	// Should catch expired
 	config.Lifetime = time.Second * time.Duration(-1)
-	c = MakeIDCookie(r, "test@test.com")
-	_, err = ValidateCookie(r, c)
+	c = makeIDCookie(r, "test@test.com")
+	_, err = validateCookie(r, c)
 	if assert.Error(err) {
 		assert.Equal("cookie has expired", err.Error())
 	}
 
 	// Should accept valid cookie
 	config.Lifetime = time.Second * time.Duration(10)
-	c = MakeIDCookie(r, "test@test.com")
-	email, err := ValidateCookie(r, c)
+	c = makeIDCookie(r, "test@test.com")
+	email, err := validateCookie(r, c)
 	assert.Nil(err, "valid request should not return an error")
 	assert.Equal("test@test.com", email, "valid request should return user email")
 }
@@ -65,31 +65,31 @@ func TestAuthValidateEmail(t *testing.T) {
 	config, _ = NewConfig([]string{})
 
 	// Should allow any
-	v := ValidateEmail("test@test.com")
+	v := validateEmail("test@test.com")
 	assert.True(v, "should allow any domain if email domain is not defined")
-	v = ValidateEmail("one@two.com")
+	v = validateEmail("one@two.com")
 	assert.True(v, "should allow any domain if email domain is not defined")
 
 	// Should block non matching domain
 	config.Domains = []string{"test.com"}
-	v = ValidateEmail("one@two.com")
+	v = validateEmail("one@two.com")
 	assert.False(v, "should not allow user from another domain")
 
 	// Should allow matching domain
 	config.Domains = []string{"test.com"}
-	v = ValidateEmail("test@test.com")
+	v = validateEmail("test@test.com")
 	assert.True(v, "should allow user from allowed domain")
 
 	// Should block non whitelisted email address
 	config.Domains = []string{}
 	config.Whitelist = []string{"test@test.com"}
-	v = ValidateEmail("one@two.com")
+	v = validateEmail("one@two.com")
 	assert.False(v, "should not allow user not in whitelist")
 
 	// Should allow matching whitelisted email address
 	config.Domains = []string{}
 	config.Whitelist = []string{"test@test.com"}
-	v = ValidateEmail("test@test.com")
+	v = validateEmail("test@test.com")
 	assert.True(v, "should allow user in whitelist")
 }
 
@@ -115,11 +115,11 @@ func TestAuthMakeCookie(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://app.example.com", nil)
 	r.Header.Add("X-Forwarded-Host", "app.example.com")
 
-	c := MakeIDCookie(r, "test@example.com")
+	c := makeIDCookie(r, "test@example.com")
 	assert.Equal("_forward_auth", c.Name)
 	parts := strings.Split(c.Value, "|")
 	assert.Len(parts, 3, "cookie should be 3 parts")
-	_, err := ValidateCookie(r, c)
+	_, err := validateCookie(r, c)
 	assert.Nil(err, "should generate valid cookie")
 	assert.Equal("/", c.Path)
 	assert.Equal("app.example.com", c.Domain)
@@ -130,7 +130,7 @@ func TestAuthMakeCookie(t *testing.T) {
 
 	config.CookieName = "testname"
 	config.InsecureCookie = true
-	c = MakeIDCookie(r, "test@example.com")
+	c = makeIDCookie(r, "test@example.com")
 	assert.Equal("testname", c.Name)
 	assert.False(c.Secure)
 }
@@ -142,22 +142,22 @@ func TestAuthMakeCSRFCookie(t *testing.T) {
 	r.Header.Add("X-Forwarded-Host", "app.example.com")
 
 	// No cookie domain or auth url
-	c := MakeCSRFCookie(r, "12345678901234567890123456789012")
+	c := makeCSRFCookie(r, "12345678901234567890123456789012")
 	assert.Equal("app.example.com", c.Domain)
 
 	// With cookie domain but no auth url
 	config = &Config{
-		CookieDomains: []CookieDomain{*NewCookieDomain("example.com")},
+		CookieDomains: []CookieDomain{*newCookieDomain("example.com")},
 	}
-	c = MakeCSRFCookie(r, "12345678901234567890123456789012")
+	c = makeCSRFCookie(r, "12345678901234567890123456789012")
 	assert.Equal("app.example.com", c.Domain)
 
 	// With cookie domain and auth url
 	config = &Config{
 		AuthHost:      "auth.example.com",
-		CookieDomains: []CookieDomain{*NewCookieDomain("example.com")},
+		CookieDomains: []CookieDomain{*newCookieDomain("example.com")},
 	}
-	c = MakeCSRFCookie(r, "12345678901234567890123456789012")
+	c = makeCSRFCookie(r, "12345678901234567890123456789012")
 	assert.Equal("example.com", c.Domain)
 }
 
@@ -165,7 +165,7 @@ func TestAuthClearCSRFCookie(t *testing.T) {
 	config = getConfigWithLifetime()
 	r, _ := http.NewRequest("GET", "http://example.com", nil)
 
-	c := ClearCSRFCookie(r)
+	c := clearCSRFCookie(r)
 	if c.Value != "" {
 		t.Error("ClearCSRFCookie should create cookie with empty value")
 	}
@@ -185,13 +185,13 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 	// Should require 32 char string
 	r := newCsrfRequest("")
 	c.Value = ""
-	valid, _, err := ValidateCSRFCookie(r, c)
+	valid, _, err := validateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
 		assert.Equal("Invalid CSRF cookie value", err.Error())
 	}
 	c.Value = "123456789012345678901234567890123"
-	valid, _, err = ValidateCSRFCookie(r, c)
+	valid, _, err = validateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
 		assert.Equal("Invalid CSRF cookie value", err.Error())
@@ -200,7 +200,7 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 	// Should require valid state
 	r = newCsrfRequest("12345678901234567890123456789012:")
 	c.Value = "12345678901234567890123456789012"
-	valid, _, err = ValidateCSRFCookie(r, c)
+	valid, _, err = validateCSRFCookie(r, c)
 	assert.False(valid)
 	if assert.Error(err) {
 		assert.Equal("Invalid CSRF state value", err.Error())
@@ -209,7 +209,7 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 	// Should allow valid state
 	r = newCsrfRequest("12345678901234567890123456789012:99")
 	c.Value = "12345678901234567890123456789012"
-	valid, state, err := ValidateCSRFCookie(r, c)
+	valid, state, err := validateCSRFCookie(r, c)
 	assert.True(valid, "valid request should return valid")
 	assert.Nil(err, "valid request should not return an error")
 	assert.Equal("99", state, "valid request should return correct state")
@@ -217,11 +217,11 @@ func TestAuthValidateCSRFCookie(t *testing.T) {
 
 func TestAuthNonce(t *testing.T) {
 	assert := assert.New(t)
-	err, nonce1 := Nonce()
+	nonce1, err := generateNonce()
 	assert.Nil(err, "error generating nonce")
 	assert.Len(nonce1, 32, "length should be 32 chars")
 
-	err, nonce2 := Nonce()
+	nonce2, err := generateNonce()
 	assert.Nil(err, "error generating nonce")
 	assert.Len(nonce2, 32, "length should be 32 chars")
 
@@ -230,7 +230,7 @@ func TestAuthNonce(t *testing.T) {
 
 func TestAuthCookieDomainMatch(t *testing.T) {
 	assert := assert.New(t)
-	cd := NewCookieDomain("example.com")
+	cd := newCookieDomain("example.com")
 
 	// Exact should match
 	assert.True(cd.Match("example.com"), "exact domain should match")

--- a/internal/authorization/authorizer.go
+++ b/internal/authorization/authorizer.go
@@ -1,5 +1,6 @@
 package authorization
 
+// Authorizer is the interface for implementing user authorization (check to see if the user can perform the action)
 type Authorizer interface {
 	Authorize(user User, requestVerb, requestResource string) (bool, error)
 }

--- a/internal/authorization/rbac/rbac.go
+++ b/internal/authorization/rbac/rbac.go
@@ -70,7 +70,7 @@ func (ra *Authorizer) getRoleFromGroups(roleNameRef, subjectGroupName string, us
 	// for every user group...
 	for _, group := range userGroups {
 		// if the group matches the group name in the subject, return the role
-		if group == subjectGroupName {
+		if strings.EqualFold(group, subjectGroupName) {
 			return ra.getRoleByName(roleNameRef)
 		}
 	}
@@ -82,7 +82,7 @@ func (ra *Authorizer) getRoleFromGroups(roleNameRef, subjectGroupName string, us
 // getRoleForSubject gets the role bound to the subject depending on the subject kind (user or group).
 // Returns nil if there is no rule matching or an unknown subject Kind is provided
 func (ra *Authorizer) getRoleForSubject(user authorization.User, subject rbacv1.Subject, roleNameRef string) *rbacv1.ClusterRole {
-	if subject.Kind == "User" && subject.Name == user.GetName() {
+	if subject.Kind == "User" && strings.EqualFold(subject.Name, user.GetName()) {
 		return ra.getRoleByName(roleNameRef)
 	} else if subject.Kind == "Group" {
 		return ra.getRoleFromGroups(roleNameRef, subject.Name, user.GetGroups())
@@ -155,7 +155,7 @@ func verbMatches(rule *rbacv1.PolicyRule, requestedVerb string) bool {
 		if ruleVerb == rbacv1.VerbAll {
 			return true
 		}
-		if strings.ToLower(ruleVerb) == strings.ToLower(requestedVerb) {
+		if strings.EqualFold(ruleVerb, requestedVerb) {
 			return true
 		}
 	}

--- a/internal/authorization/rbac/rbac_test.go
+++ b/internal/authorization/rbac/rbac_test.go
@@ -24,8 +24,8 @@ type testCase struct {
 	should bool
 }
 
-func getRBACAuthorizer(objs ...runtime.Object) *RBACAuthorizer {
-	return NewRBACAuthorizer(fake.NewSimpleClientset(objs...))
+func getRBACAuthorizer(objs ...runtime.Object) *Authorizer {
+	return NewAuthorizer(fake.NewSimpleClientset(objs...))
 }
 
 func makeRole(name string, verbs, urls []string) rbacv1.ClusterRole {
@@ -98,7 +98,7 @@ func TestRBACAuthorizer_GetRoles(t *testing.T) {
 	a := getRBACAuthorizer(roles, bindings)
 
 	u1 := authorization.User{Name: "u1"}
-	r, err := a.GetRoles(u1)
+	r, err := a.GetRolesBoundToUser(u1)
 
 	assert.NilError(t, err)
 	assert.Equal(t, len(r.Items), 2)
@@ -107,7 +107,7 @@ func TestRBACAuthorizer_GetRoles(t *testing.T) {
 
 	u2 := authorization.User{Name: "u2", Groups: []string{"g1", "g2"}}
 
-	r, err = a.GetRoles(u2)
+	r, err = a.GetRolesBoundToUser(u2)
 	assert.NilError(t, err)
 	assert.Equal(t, len(r.Items), 1)
 	assert.Equal(t, r.Items[0].Name, "r3")
@@ -139,14 +139,12 @@ func TestRBACAuthorizer_Authorize(t *testing.T) {
 	}
 }
 
-
 func TestRBACAuthorizer_Authorize2(t *testing.T) {
 	test := testCase{
 
-			user: authorization.User{Name: "boyle@ldap.forumsys.com", Groups:[]string{"oidc:chemists"}},
-			url: "/ops/portal/grafana/public/fonts/roboto/RxZJdnzeo3R5zSexge8UUVtXRa8TVwTICgirnJhmVJw.woff2",
-			should: allow,
-
+		user:   authorization.User{Name: "boyle@ldap.forumsys.com", Groups: []string{"oidc:chemists"}},
+		url:    "/ops/portal/grafana/public/fonts/roboto/RxZJdnzeo3R5zSexge8UUVtXRa8TVwTICgirnJhmVJw.woff2",
+		should: allow,
 	}
 
 	role := makeRole("grafana-admin", []string{"*"}, []string{"/ops/portal/grafana", "/ops/portal/grafana/*"})

--- a/internal/authorization/rbac/rbac_test.go
+++ b/internal/authorization/rbac/rbac_test.go
@@ -25,7 +25,7 @@ type testCase struct {
 }
 
 func getRBACAuthorizer(objs ...runtime.Object) *Authorizer {
-	return NewAuthorizer(fake.NewSimpleClientset(objs...))
+	return NewAuthorizer(fake.NewSimpleClientset(objs...), nil)
 }
 
 func makeRole(name string, verbs, urls []string) rbacv1.ClusterRole {

--- a/internal/authorization/user.go
+++ b/internal/authorization/user.go
@@ -1,14 +1,17 @@
 package authorization
 
+// User represents an autorized user
 type User struct {
 	Name   string
 	Groups []string
 }
 
+// GetName returns the user name
 func (k *User) GetName() string {
 	return k.Name
 }
 
+// GetGroups return list of groups the user belongs to
 func (k *User) GetGroups() []string {
 	return k.Groups
 }

--- a/internal/authorization/util.go
+++ b/internal/authorization/util.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 )
 
+// PathMatches returns true if the URL matches the pattern containing an optional wildcard '*' character
 func PathMatches(url, pattern string) bool {
 	return pattern == url ||
 		(strings.HasSuffix(pattern, "*") && strings.HasPrefix(url, strings.TrimRight(pattern, "*")))

--- a/internal/config.go
+++ b/internal/config.go
@@ -27,12 +27,13 @@ var (
 	log    logrus.FieldLogger
 )
 
+// Config holds app configuration
 type Config struct {
 	LogLevel  string `long:"log-level" env:"LOG_LEVEL" default:"warn" choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"fatal" choice:"panic" description:"Log level"`
 	LogFormat string `long:"log-format"  env:"LOG_FORMAT" default:"text" choice:"text" choice:"json" choice:"pretty" description:"Log format"`
 
-	ProviderUri             string               `long:"provider-uri" env:"PROVIDER_URI" description:"OIDC Provider URI"`
-	ClientId                string               `long:"client-id" env:"CLIENT_ID" description:"Client ID"`
+	ProviderURI             string               `long:"provider-uri" env:"PROVIDER_URI" description:"OIDC Provider URI"`
+	ClientID                string               `long:"client-id" env:"CLIENT_ID" description:"Client ID"`
 	ClientSecret            string               `long:"client-secret" env:"CLIENT_SECRET" description:"Client Secret" json:"-"`
 	Scope                   string               `long:"scope" env:"SCOPE" description:"Define scope"`
 	AuthHost                string               `long:"auth-host" env:"AUTH_HOST" description:"Single host to use when returning from 3rd party auth"`
@@ -198,6 +199,7 @@ func convertLegacyToIni(name string) (io.Reader, error) {
 	return bytes.NewReader(legacyFileFormat.ReplaceAll(b, []byte("$1=$2"))), nil
 }
 
+// Validate validates the provided config
 func (c *Config) Validate() {
 	// Check for show stopper errors
 	if len(c.SecretString) == 0 {
@@ -206,7 +208,7 @@ func (c *Config) Validate() {
 		log.Infoln("for better security, \"secret\" should ideally be 32 bytes or longer")
 	}
 
-	if c.ProviderUri == "" || c.ClientId == "" || c.ClientSecret == "" {
+	if c.ProviderURI == "" || c.ClientID == "" || c.ClientSecret == "" {
 		log.Fatal("provider-uri, client-id, client-secret must be set")
 	}
 
@@ -239,14 +241,17 @@ func (c *Config) Validate() {
 	}
 }
 
-func (c *Config) SetOidcProvider() {
+// LoadOIDCProviderConfiguration loads the configuration of OpenID Connect provider
+func (c *Config) LoadOIDCProviderConfiguration() error {
 	// Fetch OIDC Provider configuration
 	c.OIDCContext = context.Background()
-	provider, err := oidc.NewProvider(c.OIDCContext, c.ProviderUri)
+	provider, err := oidc.NewProvider(c.OIDCContext, c.ProviderURI)
 	if err != nil {
-		log.Fatal("failed to get provider configuration for %s: %v (hint: make sure %s is accessible from the cluster)", c.ProviderUri, err, c.ProviderUri)
+		return fmt.Errorf("failed to get provider configuration for %s: %v (hint: make sure %s is accessible from the cluster)",
+			c.ProviderURI, err, c.ProviderURI)
 	}
 	c.OIDCProvider = provider
+	return nil
 }
 
 func (c Config) String() string {

--- a/internal/server.go
+++ b/internal/server.go
@@ -39,7 +39,7 @@ func NewServer(sessionStore sessions.Store, clientset kubernetes.Interface) *Ser
 	s.buildRoutes()
 	s.sessionStore = sessionStore
 	if config.EnableRBAC {
-		s.authorizer = rbac.NewAuthorizer(clientset)
+		s.authorizer = rbac.NewAuthorizer(clientset, s.log)
 	}
 	return s
 }

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -67,7 +67,7 @@ func TestServerAuthHandlerInvalid(t *testing.T) {
 
 	// Should catch invalid cookie
 	req = newDefaultHttpRequest("/foo")
-	c := MakeIDCookie(req, "test@example.com")
+	c := makeIDCookie(req, "test@example.com")
 	parts := strings.Split(c.Value, "|")
 	c.Value = fmt.Sprintf("bad|%s|%s", parts[1], parts[2])
 
@@ -77,7 +77,7 @@ func TestServerAuthHandlerInvalid(t *testing.T) {
 
 	// Should validate email
 	req = newDefaultHttpRequest("/foo")
-	c = MakeIDCookie(req, "test@example.com")
+	c = makeIDCookie(req, "test@example.com")
 	config.Domains = []string{"test.com"}
 
 	res, _ = doHttpRequest(req, c)
@@ -93,7 +93,7 @@ func TestServerAuthHandlerExpired(t *testing.T) {
 
 	// Should redirect expired cookie
 	req := newDefaultHttpRequest("/foo")
-	c := MakeIDCookie(req, "test@example.com")
+	c := makeIDCookie(req, "test@example.com")
 	res, _ := doHttpRequest(req, c)
 	assert.Equal(307, res.StatusCode, "request with expired cookie should be redirected")
 
@@ -110,7 +110,7 @@ func TestServerAuthHandlerValid(t *testing.T) {
 	config.Lifetime = time.Minute * time.Duration(config.LifetimeString)
 	// Should allow valid request email
 	req := newDefaultHttpRequest("/foo")
-	c := MakeIDCookie(req, "test@example.com")
+	c := makeIDCookie(req, "test@example.com")
 
 	config.Domains = []string{}
 


### PR DESCRIPTION
This mostly doesn't affect the actual functionality. It documents most of the functions in go-way so that `golint` is happy and renames the functions to follow Go best practices and make their purpose more clear.

Some functions now start with a lowercase character as they are package-internal and don't need to be "exported" by having their names capitalized.

Also all logs are now logging with the first character lower-case for consistency throughout the codebase (there were more lowercased-ones so I made the others too).

The only functional changes are:

1. session expiration page for non text/html Accept header can now format JSON and XML responses optionally if `Accept` contain `application/json` or `application/xml`. For 90% of cases that doesn't have visible change. But it's a bit safer and nicer to return the content-type the app probably expects instead of just a plain text.

2. RBAC rule with User subject now matches the subject case-insensitively which makes more sense. The same applies for Group names for Group subject - they are now case-insensitive. And verb comparison (which used to be case-insensitive) now uses more appropriate `string.EqualFold(a, b)` instead of `string.ToLower(a) == string.ToLower(b)`. Those are minor changes as user names and group names should be case-insensitive and the change from case-sensitive to case-insensitive should not cause any security risk (hard to imagine having a OIDC provider with case-sensitive users, having it public and allowing anyone to create a new user PeTer to impersonate existing user Peter).

   Case-insensitive username and group comparison is in the separate commit which I can eventually remove from the pull request if desired but I suggest to use the case-insensitive comparison.

3. Optional logger is passed to the RBAC's `NewAuthorizer` to be able to log missing K8S rules to the main logger. No full rewrite of everything is necessary as comments suggested!

**extra to discuss** resyncDuration probably don't need to be configured via env/config file. I made a comment there to make it more clear what the resync does. If someone thinks it is really a thing requiring configuration, it can be passed as a new argument to  `NewAuthorizer` similarly to logger or have it as a public field of Authorizer with sane default to be able to configure it externally like so:

```go
authz := rbac.NewAuthorizer(clientset, logger)
authz.ResyncDuration = config.ResyncDuration // override the 10min default
```

**all tests are ok as before (I intentionally left the %w bug there as #27 fixes this)**