### PR TITLE
Bump Go version to 1.14; also speeds up builds thanks to module proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-alpine as builder
+FROM golang:1.14-alpine as builder
 
 # Setup
 RUN mkdir -p /go/src/github.com/mesosphere/traefik-forward-auth


### PR DESCRIPTION
Unless you have a particular reason not to, I suggest to update Dockerfile for latest stable Go 1.14.

In addition to many invisible changes, Go 1.13 configures [module proxy](https://proxy.golang.org/) by default which speeds up compilation times significantly.