### PR TITLE
fix: trim name claims surrounded by quotes

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -290,9 +290,16 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 			name = email.(string)
 		}
 
-		http.SetCookie(w, MakeNameCookie(r, name.(string)))
+		nameStr := name.(string)
+
+		// Some claims, such as github name, arrive surrounded by quotation marks
+		if strings.HasPrefix(nameStr, `"`) && strings.HasSuffix(nameStr, `"`) {
+			nameStr = strings.TrimFunc(nameStr, func(r rune) bool { return r == '"' })
+		}
+
+		http.SetCookie(w, MakeNameCookie(r, nameStr))
 		logger.WithFields(logrus.Fields{
-			"name": name.(string),
+			"name": nameStr,
 		}).Infof("Generated name cookie")
 
 		// Mapping groups


### PR DESCRIPTION
I observed that name cookies from github OAuth are unnecessarily surrounded by quotation marks:

This is the default console auth:
![Screenshot from 2020-06-09 11-18-04](https://user-images.githubusercontent.com/174332/84183582-5abea700-aa49-11ea-82e0-d1cbdd606ae2.png)

This is OneLogin:
![Screenshot from 2020-06-09 11-18-47](https://user-images.githubusercontent.com/174332/84183612-68742c80-aa49-11ea-9dcd-a45c74427e52.png)

...And this is github:
![Screenshot from 2020-06-09 11-24-19](https://user-images.githubusercontent.com/174332/84183628-6e6a0d80-aa49-11ea-9ff5-3a948526644b.png)

Do you have any insight into this? I couldn't find mention of this issue, nor did I dig very deeply into github's oauth id token to get a sense of why these quotation marks exist. I also didn't smoke test this change because I'm not exactly sure how to do so. I'd love to learn how or see this process documented.

I'm not a golang programmer so please review carefully. I understood `name.(string)` to panic if name is indeed not a string.
