### PR TITLE
Use X-Replaced-Path header if present

### DIFF
--- a/internal/auth.go
+++ b/internal/auth.go
@@ -84,9 +84,14 @@ func redirectBase(r *http.Request) string {
 }
 
 func GetUriPath(r *http.Request) string {
-	prefix := r.Header.Get("X-Forwarded-Prefix")
-	uri := r.Header.Get("X-Forwarded-Uri")
-	return fmt.Sprintf("%s/%s", strings.TrimRight(prefix, "/"), strings.TrimLeft(uri, "/"))
+	// Use X-Replaced-Path if present (Traefik Modifiers)
+	if r.Header.Get("X-Replaced-Path") != "" {
+		return r.Header.Get("X-Replaced-Path")
+	} else {
+		prefix := r.Header.Get("X-Forwarded-Prefix")
+		uri := r.Header.Get("X-Forwarded-Uri")
+		return fmt.Sprintf("%s/%s", strings.TrimRight(prefix, "/"), strings.TrimLeft(uri, "/"))
+	}
 }
 
 // // Return url

--- a/internal/server.go
+++ b/internal/server.go
@@ -80,6 +80,7 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 		"X-Forwarded-Host":   r.Header.Get("X-Forwarded-Host"),
 		"X-Forwarded-Prefix": r.Header.Get("X-Forwarded-Prefix"),
 		"X-Forwarded-Uri":    r.Header.Get("X-Forwarded-Uri"),
+		"X-Replaced-Path":    r.Header.Get("X-Replaced-Path"),
 	})
 
 	// Modify request

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -304,6 +304,18 @@ func TestServerRoutePath(t *testing.T) {
 	req = newDefaultHttpRequest("/private/path")
 	res, _ = doHttpRequest(req, nil)
 	assert.Equal(200, res.StatusCode, "request matching allow rule should be allowed")
+
+	// Should allow matching request
+	req = newDefaultHttpRequest("/path")
+	req.Header.Add("X-Forwarded-Prefix", "/private")
+	res, _ = doHttpRequest(req, nil)
+	assert.Equal(200, res.StatusCode, "request matching allow rule should be allowed")
+
+	// Should allow matching request
+	req = newDefaultHttpRequest("/replaced/path")
+	req.Header.Add("X-Replaced-Path", "/private/path")
+	res, _ = doHttpRequest(req, nil)
+	assert.Equal(200, res.StatusCode, "request matching allow rule should be allowed")
 }
 
 func TestServerRouteQuery(t *testing.T) {


### PR DESCRIPTION
Adapted from https://github.com/thomseddon/traefik-forward-auth/pull/49.

This causes Traefik Forward Auth to use the value of the `X-Replaced-Path` header as the request path when evaluating whether a request is allowed. Traefik sets this header when it alters a request path using `ReplacePathRegex`, see https://doc.traefik.io/traefik/v2.0/middlewares/replacepathregex/. Without this change, Traefik Forward Auth will use the rewritten request path. If rules are defined with the expectation that they apply to requests before they are rewritten, this can lead to unexpected authorization errors.

https://jira.d2iq.com/browse/D2IQ-71985