### PR TITLE
(v2) Use X-Replaced-Path header if present

### DIFF
--- a/internal/auth.go
+++ b/internal/auth.go
@@ -84,9 +84,14 @@ func redirectBase(r *http.Request) string {
 }
 
 func GetUriPath(r *http.Request) string {
-	prefix := r.Header.Get("X-Forwarded-Prefix")
-	uri := r.Header.Get("X-Forwarded-Uri")
-	return fmt.Sprintf("%s/%s", strings.TrimRight(prefix, "/"), strings.TrimLeft(uri, "/"))
+	// Use X-Replaced-Path if present (Traefik Modifiers)
+	if r.Header.Get("X-Replaced-Path") != "" {
+		return r.Header.Get("X-Replaced-Path")
+	} else {
+		prefix := r.Header.Get("X-Forwarded-Prefix")
+		uri := r.Header.Get("X-Forwarded-Uri")
+		return fmt.Sprintf("%s/%s", strings.TrimRight(prefix, "/"), strings.TrimLeft(uri, "/"))
+	}
 }
 
 // // Return url

--- a/internal/server.go
+++ b/internal/server.go
@@ -80,6 +80,7 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 		"X-Forwarded-Host":   r.Header.Get("X-Forwarded-Host"),
 		"X-Forwarded-Prefix": r.Header.Get("X-Forwarded-Prefix"),
 		"X-Forwarded-Uri":    r.Header.Get("X-Forwarded-Uri"),
+		"X-Replaced-Path":    r.Header.Get("X-Replaced-Path"),
 	})
 
 	// Modify request

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -304,6 +304,18 @@ func TestServerRoutePath(t *testing.T) {
 	req = newDefaultHttpRequest("/private/path")
 	res, _ = doHttpRequest(req, nil)
 	assert.Equal(200, res.StatusCode, "request matching allow rule should be allowed")
+
+	// Should allow matching request
+	req = newDefaultHttpRequest("/path")
+	req.Header.Add("X-Forwarded-Prefix", "/private")
+	res, _ = doHttpRequest(req, nil)
+	assert.Equal(200, res.StatusCode, "request matching allow rule should be allowed")
+
+	// Should allow matching request
+	req = newDefaultHttpRequest("/replaced/path")
+	req.Header.Add("X-Replaced-Path", "/private/path")
+	res, _ = doHttpRequest(req, nil)
+	assert.Equal(200, res.StatusCode, "request matching allow rule should be allowed")
 }
 
 func TestServerRouteQuery(t *testing.T) {


### PR DESCRIPTION
This is a v2 backport of #37.

https://jira.d2iq.com/browse/D2IQ-71985

I tested this PR by building and pushing a docker image that I then deployed as part of the traefik-forward-auth kubeaddon.

From `cluster.yaml`:
```
        - name: traefik-forward-auth
          enabled: true
          values: |
            image:
              repository: branden/traefik-forward-auth
              tag: x-replaced-path-2.0.5
```