### PR TITLE
fix: remove authentication headers from Connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
 format:
-	gofmt -w -s internal/*.go cmd/*.go
+	gofmt -w -s internal/**/*.go cmd/*.go
 
 .PHONY: format

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -315,6 +315,21 @@ func TestAuthzDisabled(t *testing.T) {
 	assert.Equal(s.authzIsBypassed(r), true)
 }
 
+func TestCleanupConnection(t *testing.T) {
+	assert := assert.New(t)
+	tests := map[string]string{
+		"":                                 "",
+		"Authorization":                    "",
+		"keep-alive":                       "keep-alive",
+		"keep-alive, AUTHORIZATION":        "keep-alive",
+		"Authorization, Other":             "Other",
+		"keep-alive, authorization, Other": "keep-alive, Other",
+	}
+	for original, expected := range tests {
+		assert.Equal(expected, cleanupConnectionHeader(original))
+	}
+}
+
 /**
  * Utilities
  */


### PR DESCRIPTION
Back-port of https://github.com/mesosphere/traefik-forward-auth/pull/42 to v3 branch.

Note, I created `v3` branch to continue from `v3.0.0` which is currently both a branch and a tag.

We plan to tag a `v3.0.1` shortly for deployment in DKP.