### PR TITLE
Make errors consistent

### DIFF
--- a/internal/auth.go
+++ b/internal/auth.go
@@ -118,15 +118,15 @@ func useAuthDomain(r *http.Request, authHost string, cookieDomains []CookieDomai
 // Cookie methods
 
 // makeSessionCookie creates an authenticated and encrypted cookie holding session data
-func makeSessionCookie(r *http.Request, config *Config, data sessionCookie) *http.Cookie {
+func makeSessionCookie(r *http.Request, config *Config, data sessionCookie) (*http.Cookie, error) {
 	sc := securecookie.New([]byte(config.SecretString), []byte(config.EncryptionKeyString)).MaxAge(config.CookieMaxAge())
 
 	encoded, err := sc.Encode(config.CookieName, data)
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
-	return &http.Cookie{
+	cookie := &http.Cookie{
 		Name:     config.CookieName,
 		Value:    encoded,
 		Path:     "/",
@@ -135,6 +135,8 @@ func makeSessionCookie(r *http.Request, config *Config, data sessionCookie) *htt
 		Secure:   !config.InsecureCookie,
 		Expires:  config.CookieExpiry(),
 	}
+
+	return cookie, nil
 }
 
 // makeNameCookie creates a name cookie

--- a/internal/auth_test.go
+++ b/internal/auth_test.go
@@ -50,7 +50,8 @@ func TestAuthValidateCookie(t *testing.T) {
 
 	// Should catch expired
 	config.Lifetime = time.Second * time.Duration(-1)
-	c = makeSessionCookie(r, config, sessionCookie{EMail: "test@test.com"})
+	c, err = makeSessionCookie(r, config, sessionCookie{EMail: "test@test.com"})
+	assert.Nil(err)
 	_, err = validateSessionCookie(r, c, config)
 	if assert.Error(err) {
 		assert.Equal("securecookie: expired timestamp", err.Error())
@@ -58,7 +59,8 @@ func TestAuthValidateCookie(t *testing.T) {
 
 	// Should accept valid cookie
 	config.Lifetime = time.Second * time.Duration(10)
-	c = makeSessionCookie(r, config, sessionCookie{EMail: "test@test.com"})
+	c, err = makeSessionCookie(r, config, sessionCookie{EMail: "test@test.com"})
+	assert.Nil(err)
 	sess, err := validateSessionCookie(r, c, config)
 	assert.Nil(err, "valid request should not return an error")
 	assert.Equal("test@test.com", sess.EMail, "valid request should return user email")
@@ -110,7 +112,8 @@ func TestAuthMakeCookie(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://app.example.com", nil)
 	r.Header.Add("X-Forwarded-Host", "app.example.com")
 
-	c := makeSessionCookie(r, config, sessionCookie{EMail: "test@example.com"})
+	c, err := makeSessionCookie(r, config, sessionCookie{EMail: "test@example.com"})
+	assert.Nil(err)
 	assert.Equal("_forward_auth", c.Name)
 	assert.Greater(len(c.Value), 18, "encoded securecookie should be longer")
 	_, err := validateSessionCookie(r, c, config)
@@ -124,7 +127,8 @@ func TestAuthMakeCookie(t *testing.T) {
 
 	config.CookieName = "testname"
 	config.InsecureCookie = true
-	c = makeSessionCookie(r, config, sessionCookie{EMail: "test@example.com"})
+	c, err = makeSessionCookie(r, config, sessionCookie{EMail: "test@example.com"})
+	assert.Nil(err)
 	assert.Equal("testname", c.Name)
 	assert.False(c.Secure)
 }

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -39,7 +39,8 @@ func TestServerAuthHandlerInvalid(t *testing.T) {
 
 	// Should catch invalid cookie
 	req = newDefaultHTTPRequest("/foo")
-	c := makeSessionCookie(req, config, sessionCookie{EMail: "test@example.com"})
+	c, err := makeSessionCookie(req, config, sessionCookie{EMail: "test@example.com"})
+	assert.Nil(err)
 	config = newTestConfig(testAuthKey2, testEncKey2) // new auth & encryption key!
 
 	config.AuthHost = ""
@@ -48,7 +49,8 @@ func TestServerAuthHandlerInvalid(t *testing.T) {
 
 	// Should validate email
 	req = newDefaultHTTPRequest("/foo")
-	c = makeSessionCookie(req, config, sessionCookie{EMail: "test@example.com"})
+	c, err = makeSessionCookie(req, config, sessionCookie{EMail: "test@example.com"})
+	assert.Nil(err)
 	config.Domains = []string{"test.com"}
 
 	res, _ = doHTTPRequest(config, req, c)
@@ -64,7 +66,8 @@ func TestServerAuthHandlerExpired(t *testing.T) {
 
 	// Should redirect expired cookie
 	req := newDefaultHTTPRequest("/foo")
-	c := makeSessionCookie(req, config, sessionCookie{EMail: "test@example.com"})
+	c, err := makeSessionCookie(req, config, sessionCookie{EMail: "test@example.com"})
+	assert.Nil(err)
 	res, _ := doHTTPRequest(config, req, c)
 	assert.Equal(307, res.StatusCode, "request with expired cookie should be redirected")
 
@@ -81,7 +84,8 @@ func TestServerAuthHandlerValid(t *testing.T) {
 	config.Lifetime = time.Minute * time.Duration(config.LifetimeString)
 	// Should allow valid request email
 	req := newDefaultHTTPRequest("/foo")
-	c := makeSessionCookie(req, config, sessionCookie{EMail: "test@example.com"})
+	c, err := makeSessionCookie(req, config, sessionCookie{EMail: "test@example.com"})
+	assert.Nil(err)
 
 	config.Domains = []string{}
 


### PR DESCRIPTION
`makeSessionCookie` turns its err value into a nil, losing its info. This makes it difficult to debug problems.

For consistency make fatal problems use `Error` and non-fatal problems use `Warn`.