### PR TITLE
Adds configuration for OAuth library's authentication style.

### DIFF
--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"golang.org/x/oauth2"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -30,6 +31,7 @@ var (
 
 // Config holds app configuration
 type Config struct {
+	AuthStyle string `long:"auth-style" env:"AUTH_STYLE" default:"auto-detect" choice:"auto-detect" choice:"header" choice:"params" description:"Optionally choose the authentication style of the OAuth2 library."`
 	LogLevel  string `long:"log-level" env:"LOG_LEVEL" default:"warn" choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"fatal" choice:"panic" description:"Log level"`
 	LogFormat string `long:"log-format"  env:"LOG_FORMAT" default:"text" choice:"text" choice:"json" choice:"pretty" description:"Log format"`
 
@@ -131,6 +133,17 @@ func (c *Config) parseFlags(args []string) error {
 	}
 
 	return nil
+}
+
+func (c *Config) ParseAuthStyle() oauth2.AuthStyle {
+	switch c.AuthStyle {
+	case "header":
+		return oauth2.AuthStyleInHeader
+	case "params":
+		return oauth2.AuthStyleInParams
+	default:
+		return oauth2.AuthStyleAutoDetect
+	}
 }
 
 func (c *Config) parseUnknownFlag(option string, arg flags.SplitArgument, args []string) ([]string, error) {

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -290,12 +290,17 @@ func (s *Server) AuthCallbackHandler() http.HandlerFunc {
 			scope = []string{oidc.ScopeOpenID, "profile", "email", "groups"}
 		}
 
+		endpoint := provider.Endpoint()
 		oauth2Config := oauth2.Config{
 			ClientID:     s.config.ClientID,
 			ClientSecret: s.config.ClientSecret,
 			RedirectURL:  s.authenticator.ComposeRedirectURI(r),
-			Endpoint:     provider.Endpoint(),
-			Scopes:       scope,
+			Endpoint: oauth2.Endpoint{
+				AuthStyle: s.config.ParseAuthStyle(),
+				AuthURL:   endpoint.AuthURL,
+				TokenURL:  endpoint.TokenURL,
+			},
+			Scopes: scope,
 		}
 
 		// Exchange code for token


### PR DESCRIPTION
This pull requests adds the possibility to configure the OAuth library's authentication style. Some OAuth providers don't support the auto detection that is used by default (e.g. AWS Cognito).

I already contributed this to the original [traefik-forward-auth](https://github.com/thomseddon/traefik-forward-auth/pull/271). As it was never merged and the project seems to be dead right now, I want to contribute the feature here and move to the mesosphere fork in my environment.

As I'm not a pro in golang yet, I wasn't sure if there is any smart test scenario that could be added to `server_test.go` (e.g. something that tests the auth style is correct in the request). If you have any ideas/suggestions, please let me know and I will adapt it as well.