### PR TITLE
QueryEscape the original URL in the state parameter

### DIFF
--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -461,7 +461,11 @@ func (s *Server) authRedirect(logger *logrus.Entry, w http.ResponseWriter, r *ht
 		Scopes:       scope,
 	}
 
-	state := fmt.Sprintf("%s:%s", nonce, authentication.GetRequestURL(r))
+	// QueryEscape the URL of the original URL in the query parameter
+	// because if it contains a "&" character, it will be parsed as another
+	// query parameter, losing part of the query when redirecting back to
+	// the original URL.
+	state := fmt.Sprintf("%s:%s", nonce, neturl.QueryEscape(authentication.GetRequestURL(r)))
 
 	http.Redirect(w, r, oauth2Config.AuthCodeURL(state), http.StatusFound)
 


### PR DESCRIPTION
QueryEscape the URL of the original URL in the query parameter because if it contains a "&" character, it will be parsed as another query parameter, losing part of the query when redirecting back to theoriginal URL.

For example (the query patterned from a google search),
https://app1.example.com/path/to/something?q=query+strings&source=hp&ei=IKG0Cg&sclient=gws-wiz
would redirect back to
https://app1.example.com/path/to/something?q=query strings

Applying QueryEscape to the URL before appending it to the state query parameter solves this problem.