### PR TITLE
Send configured claims as headers to backends

### DIFF
--- a/internal/api/storage/v1alpha1/types.go
+++ b/internal/api/storage/v1alpha1/types.go
@@ -1,7 +1,8 @@
 package v1alpha1
 
 type UserInfo struct {
-	Username string   `json:"username"`
-	Email    string   `json:"email"`
-	Groups   []string `json:"groups"`
+	Username    string            `json:"username"`
+	Email       string            `json:"email"`
+	Groups      []string          `json:"groups"`
+	ExtraClaims map[string]string `json:"extraClaims"`
 }

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	GroupClaimPrefix        string               `long:"group-claim-prefix" env:"GROUP_CLAIM_PREFIX" default:"oidc:" description:"prefix oidc group claims with this value"`
 	EncryptionKeyString     string               `long:"encryption-key" env:"ENCRYPTION_KEY" description:"Encryption key used to encrypt the cookie (required)" json:"-"`
 	GroupsAttributeName     string               `long:"groups-attribute-name" env:"GROUPS_ATTRIBUTE_NAME" default:"groups" description:"Map the correct attribute that contain the user groups"`
+	ExtraClaims             map[string]string    `long:"extra-claims" env:"EXTRA_CLAIMS" description:"List of extra claims in the jwt to pass as headers. Format is 'Header-Name:claim-name'" env-delim:","`
 
 	// RBAC
 	EnableRBAC              bool               `long:"enable-rbac" env:"ENABLE_RBAC" description:"Indicates that RBAC support should be enabled"`

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -215,7 +215,6 @@ func (s *Server) AuthHandler(rule string) http.HandlerFunc {
 
 		// Map extra claims to headers
 		for k, v := range session.ExtraClaims {
-			logger.Debugf("Setting header %s to %s", k, v)
 			w.Header().Set(k, v)
 		}
 


### PR DESCRIPTION
This PR add the possibility to configure generic claims to be passed to backends as headers.

It is related to this comment https://github.com/mesosphere/traefik-forward-auth/issues/64#issuecomment-1073260776 which is by far the most upvoted comment in this repository

Just as an example: if you set `EXTRA_CLAIMS = "x-forwarded-locale:locale, x-forwarded-picture:picture"` then your backends will receive two new headers: `X-Forwarded-Locale`, containing the value inside the `locale` claim, and `X-Forwarded-Picture`, containing the value inside the claim `picture`

Note: remember also to add [`authResponseHeaders`](https://doc.traefik.io/traefik/middlewares/http/forwardauth/#authresponseheaders) or [`authResponseHeadersRegex`](https://doc.traefik.io/traefik/middlewares/http/forwardauth/#authresponseheadersregex) to your middleware appropriately of course