### PR TITLE
Allow configuring headers to forward from the original request

### DIFF
--- a/internal/authorization/rbac/rbac.go
+++ b/internal/authorization/rbac/rbac.go
@@ -22,7 +22,7 @@ const (
 	// This creates a higher guarantee that your informer’s store has a perfect picture of the resources it is watching.
 	// There are situations where events can be missed entirely and resyncing every so often solves this.
 	// Setting to 0 disables the resync and makes the informer subscribe to individual updates only.
-	defaultResyncDuration =  time.Minute * 10
+	defaultResyncDuration = time.Minute * 10
 )
 
 // Logger is an interface for basic log output

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -60,6 +60,7 @@ type Config struct {
 	GroupClaimPrefix        string               `long:"group-claim-prefix" env:"GROUP_CLAIM_PREFIX" default:"oidc:" description:"prefix oidc group claims with this value"`
 	EncryptionKeyString     string               `long:"encryption-key" env:"ENCRYPTION_KEY" description:"Encryption key used to encrypt the cookie (required)" json:"-"`
 	GroupsAttributeName     string               `long:"groups-attribute-name" env:"GROUPS_ATTRIBUTE_NAME" default:"groups" description:"Map the correct attribute that contain the user groups"`
+	ForwardHeaders          string               `long:"forward-headers" env:"FORWARD_HEADERS" default:"" description:"Headers to forward to the upstream, separated by a comma. For example: X-CSRF-Token,X-Requested-With"`
 
 	// RBAC
 	EnableRBAC              bool               `long:"enable-rbac" env:"ENABLE_RBAC" description:"Indicates that RBAC support should be enabled"`

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -95,6 +95,8 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 		"X-Forwarded-Host":   r.Header.Get("X-Forwarded-Host"),
 		"X-Forwarded-Prefix": r.Header.Get("X-Forwarded-Prefix"),
 		"X-Forwarded-Uri":    r.Header.Get("X-Forwarded-Uri"),
+		"X-CSRFToken":        r.Header.Get("X-CSRFToken"),
+		"X-Requested-With":   r.Header.Get("X-Requested-With"),
 	})
 
 	// Modify request
@@ -227,6 +229,9 @@ func (s *Server) AuthHandler(rule string) http.HandlerFunc {
 		if s.config.ForwardTokenHeaderName != "" && id.Token != "" {
 			w.Header().Add(s.config.ForwardTokenHeaderName, s.config.ForwardTokenPrefix+id.Token)
 		}
+
+		w.Header().Add("X-CSRFToken", r.Header.Get("X-CSRFToken"));
+		w.Header().Add("X-Requested-With", r.Header.Get("X-Requested-With"));
 
 		w.WriteHeader(200)
 	}

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -95,8 +95,6 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 		"X-Forwarded-Host":   r.Header.Get("X-Forwarded-Host"),
 		"X-Forwarded-Prefix": r.Header.Get("X-Forwarded-Prefix"),
 		"X-Forwarded-Uri":    r.Header.Get("X-Forwarded-Uri"),
-		"X-CSRFToken":        r.Header.Get("X-CSRFToken"),
-		"X-Requested-With":   r.Header.Get("X-Requested-With"),
 	})
 
 	// Modify request
@@ -230,8 +228,14 @@ func (s *Server) AuthHandler(rule string) http.HandlerFunc {
 			w.Header().Add(s.config.ForwardTokenHeaderName, s.config.ForwardTokenPrefix+id.Token)
 		}
 
-		w.Header().Add("X-CSRFToken", r.Header.Get("X-CSRFToken"));
-		w.Header().Add("X-Requested-With", r.Header.Get("X-Requested-With"));
+		// Get all headers that we want to forward from the original request
+		// by reading the config
+		headers := strings.Split(s.config.ForwardHeaders, ",")
+
+		// Forward headers
+		for _, header := range headers {
+			w.Header().Add(header, r.Header.Get(header))
+		}
 
 		w.WriteHeader(200)
 	}


### PR DESCRIPTION
Allow users to make a config to specify headers they want to forward from the original request