### PR TITLE
fix: canonicalize Host matching for trailing-dot hosts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,8 +9,7 @@ jobs:
   build:
     name: Run Go tests
     runs-on:
-      - self-hosted
-      - medium
+      - self-hosted-nutanix-docker-medium
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -198,6 +198,8 @@ func handleFlagError(err error) error {
 }
 
 var legacyFileFormat = regexp.MustCompile(`(?m)^([a-z-]+) (.*)$`)
+var hostMatcher = regexp.MustCompile(`Host\(([^)]*)\)`)
+var backtickHostArg = regexp.MustCompile("`([^`]*)`")
 
 func convertLegacyToIni(name string) (io.Reader, error) {
 	b, err := ioutil.ReadFile(name)
@@ -287,9 +289,22 @@ func NewRule() *Rule {
 }
 
 func (r *Rule) FormattedRule() string {
+	canonicalizedHostRule := hostMatcher.ReplaceAllStringFunc(r.Rule, func(m string) string {
+		args := strings.TrimSuffix(strings.TrimPrefix(m, "Host("), ")")
+		canonicalizedArgs := backtickHostArg.ReplaceAllStringFunc(args, func(arg string) string {
+			host := strings.TrimSuffix(strings.TrimPrefix(arg, "`"), "`")
+			return fmt.Sprintf("`%s`", canonicalizeHost(host))
+		})
+		return fmt.Sprintf("Host(%s)", canonicalizedArgs)
+	})
+
 	// Traefik implements their own "Host" matcher and then offers "HostRegexp"
 	// to invoke the mux "Host" matcher. This ensures the mux version is used
-	return strings.ReplaceAll(r.Rule, "Host(", "HostRegexp(")
+	return strings.ReplaceAll(canonicalizedHostRule, "Host(", "HostRegexp(")
+}
+
+func canonicalizeHost(host string) string {
+	return strings.TrimSuffix(strings.ToLower(host), ".")
 }
 
 // Validate validates the rule

--- a/internal/configuration/config_test.go
+++ b/internal/configuration/config_test.go
@@ -160,3 +160,20 @@ func TestConfigCommaSeparatedList(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal("one,two", marshal, "should marshal back to comma sepearated list")
 }
+
+func TestFormattedRuleCanonicalizesHost(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal("HostRegexp(`admin.rig.test`)", (&Rule{Rule: "Host(`admin.rig.test`)"}).FormattedRule())
+	assert.Equal("HostRegexp(`admin.rig.test`)", (&Rule{Rule: "Host(`admin.rig.test.`)"}).FormattedRule())
+	assert.Equal("HostRegexp(`admin.rig.test`)", (&Rule{Rule: "Host(`Admin.Rig.Test.`)"}).FormattedRule())
+	assert.Equal(
+		"HostRegexp(`admin.rig.test`) && Path(`/x`)",
+		(&Rule{Rule: "Host(`admin.rig.test.`) && Path(`/x`)"}).FormattedRule(),
+	)
+	assert.Equal(
+		"HostRegexp(`admin.rig.test`,`other.example.com`)",
+		(&Rule{Rule: "Host(`admin.rig.test.`,`other.example.com.`)"}).FormattedRule(),
+	)
+	assert.Equal("HostRegexp(`admin.rig.test.`)", (&Rule{Rule: "HostRegexp(`admin.rig.test.`)"}).FormattedRule())
+}

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -116,6 +116,11 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// canonicalizeForwardedHost makes X-Forwarded-Host match the host Traefik
+// already routed on: lowercase and strip one trailing dot (DNS absolute form,
+// e.g. admin.example.com.). The port is split off first so IPv6 literals and
+// ":443" stay intact. Two trailing dots are left as-is; Traefik does not
+// route those, so this service is never consulted.
 func canonicalizeForwardedHost(forwardedHost string) string {
 	if forwardedHost == "" {
 		return ""
@@ -127,6 +132,8 @@ func canonicalizeForwardedHost(forwardedHost string) string {
 		host = splitHost
 		port = splitPort
 	} else if i := strings.LastIndex(forwardedHost, ":"); i > 0 {
+		// Fallback for host:port when SplitHostPort rejects the value.
+		// Skip if the left side already has a colon (unbracketed IPv6).
 		possiblePort := forwardedHost[i+1:]
 		if _, err := strconv.Atoi(possiblePort); err == nil && !strings.Contains(forwardedHost[:i], ":") {
 			host = forwardedHost[:i]

--- a/internal/handlers/server.go
+++ b/internal/handlers/server.go
@@ -2,9 +2,11 @@ package handlers
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	neturl "net/url"
+	"strconv"
 	"strings"
 
 	"github.com/mesosphere/traefik-forward-auth/internal/api/storage/v1alpha1"
@@ -99,10 +101,10 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Modify request
 	r.Method = r.Header.Get("X-Forwarded-Method")
-	r.Host = r.Header.Get("X-Forwarded-Host")
+	r.Host = canonicalizeForwardedHost(r.Header.Get("X-Forwarded-Host"))
 	r.URL, _ = neturl.Parse(authentication.GetRequestURI(r))
 
-	if s.config.AuthHost == "" || len(s.config.CookieDomains) > 0 || r.Host == s.config.AuthHost {
+	if s.config.AuthHost == "" || len(s.config.CookieDomains) > 0 || r.Host == canonicalizeForwardedHost(s.config.AuthHost) {
 		s.router.ServeHTTP(w, r)
 	} else {
 		// Redirect the client to the authHost.
@@ -112,6 +114,32 @@ func (s *Server) RootHandler(w http.ResponseWriter, r *http.Request) {
 		logger.Debugf("redirect to %v", url.String())
 		http.Redirect(w, r, url.String(), 307)
 	}
+}
+
+func canonicalizeForwardedHost(forwardedHost string) string {
+	if forwardedHost == "" {
+		return ""
+	}
+
+	host := forwardedHost
+	port := ""
+	if splitHost, splitPort, err := net.SplitHostPort(forwardedHost); err == nil {
+		host = splitHost
+		port = splitPort
+	} else if i := strings.LastIndex(forwardedHost, ":"); i > 0 {
+		possiblePort := forwardedHost[i+1:]
+		if _, err := strconv.Atoi(possiblePort); err == nil && !strings.Contains(forwardedHost[:i], ":") {
+			host = forwardedHost[:i]
+			port = possiblePort
+		}
+	}
+
+	canonicalizedHost := strings.TrimSuffix(strings.ToLower(host), ".")
+	if port == "" {
+		return canonicalizedHost
+	}
+
+	return net.JoinHostPort(canonicalizedHost, port)
 }
 
 // AllowHandler handles the request as implicite "allow", returining HTTP 200 response to the Traefik

--- a/internal/handlers/server_host_canonical_test.go
+++ b/internal/handlers/server_host_canonical_test.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mesosphere/traefik-forward-auth/internal/configuration"
+)
+
+// TestServerHostCanonicalAuthRuleDefaultAllow is the unauthenticated bypass:
+// default-action=allow with a Host(...) auth rule. Traefik routes both the
+// canonical Host and the single-trailing-dot spelling to the same backend;
+// both must select the auth rule, not fall through to allow.
+func TestServerHostCanonicalAuthRuleDefaultAllow(t *testing.T) {
+	assert := assert.New(t)
+	config := newTestConfig(testAuthKey1, testEncKey1)
+	config.DefaultAction = "allow"
+	config.AuthHost = ""
+	config.Rules = map[string]*configuration.Rule{
+		"admin": {
+			Action: "auth",
+			Rule:   "Host(`admin.rig.test`)",
+		},
+	}
+
+	for _, host := range []string{"admin.rig.test", "admin.rig.test.", "Admin.Rig.Test."} {
+		req := newForwardedRequest(host)
+		res, _ := doHttpRequest(req, nil, config)
+		assert.Equal(401, res.StatusCode, "host %q must require auth", host)
+	}
+
+	req := newForwardedRequest("other.rig.test")
+	res, _ := doHttpRequest(req, nil, config)
+	assert.Equal(200, res.StatusCode, "unrelated host should use default allow")
+}
+
+// TestServerHostCanonicalDottedRule covers the inverse: a rule written with a
+// trailing dot must still match the canonical Host, so writing the dotted form
+// is not a workaround.
+func TestServerHostCanonicalDottedRule(t *testing.T) {
+	assert := assert.New(t)
+	config := newTestConfig(testAuthKey1, testEncKey1)
+	config.DefaultAction = "allow"
+	config.AuthHost = ""
+	config.Rules = map[string]*configuration.Rule{
+		"admin": {
+			Action: "auth",
+			Rule:   "Host(`admin.rig.test.`)",
+		},
+	}
+
+	for _, host := range []string{"admin.rig.test", "admin.rig.test."} {
+		req := newForwardedRequest(host)
+		res, _ := doHttpRequest(req, nil, config)
+		assert.Equal(401, res.StatusCode, "host %q must match dotted Host rule", host)
+	}
+}
+
+func TestServerHostCanonicalAllowRuleDefaultAuth(t *testing.T) {
+	assert := assert.New(t)
+	config := newTestConfig(testAuthKey1, testEncKey1)
+	config.DefaultAction = "auth"
+	config.AuthHost = ""
+	config.Rules = map[string]*configuration.Rule{
+		"public": {
+			Action: "allow",
+			Rule:   "Host(`public.rig.test`)",
+		},
+	}
+
+	for _, host := range []string{"public.rig.test", "public.rig.test."} {
+		req := newForwardedRequest(host)
+		res, _ := doHttpRequest(req, nil, config)
+		assert.Equal(200, res.StatusCode, "host %q must match allow rule", host)
+	}
+
+	req := newForwardedRequest("other.rig.test")
+	res, _ := doHttpRequest(req, nil, config)
+	assert.Equal(401, res.StatusCode, "unrelated host should use default auth")
+}
+
+func TestServerHostRegexpLeftAlone(t *testing.T) {
+	assert := assert.New(t)
+	config := newTestConfig(testAuthKey1, testEncKey1)
+	config.DefaultAction = "allow"
+	config.AuthHost = ""
+	config.Rules = map[string]*configuration.Rule{
+		"admin": {
+			Action: "auth",
+			Rule:   "HostRegexp(`admin.rig.test.`)",
+		},
+	}
+
+	// HostRegexp arguments are not rewritten. After request-host
+	// canonicalization the mux never sees a trailing dot, so a dotted
+	// HostRegexp matches neither spelling.
+	for _, host := range []string{"admin.rig.test", "admin.rig.test."} {
+		req := newForwardedRequest(host)
+		res, _ := doHttpRequest(req, nil, config)
+		assert.Equal(200, res.StatusCode, "HostRegexp must not be auto-canonicalized; host %q", host)
+	}
+}
+
+func TestServerAuthHostTrailingDot(t *testing.T) {
+	assert := assert.New(t)
+	config := newTestConfig(testAuthKey1, testEncKey1)
+	config.DefaultAction = "allow"
+	config.AuthHost = "auth.example.com"
+
+	req := newForwardedRequest("auth.example.com.")
+	res, _ := doHttpRequest(req, nil, config)
+	assert.Equal(200, res.StatusCode, "dotted auth host must be treated as the auth host")
+}
+
+func TestCanonicalizeForwardedHost(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Equal("", canonicalizeForwardedHost(""))
+	assert.Equal("admin.rig.test", canonicalizeForwardedHost("admin.rig.test"))
+	assert.Equal("admin.rig.test", canonicalizeForwardedHost("admin.rig.test."))
+	assert.Equal("admin.rig.test.", canonicalizeForwardedHost("admin.rig.test.."))
+	assert.Equal("admin.rig.test", canonicalizeForwardedHost("Admin.Rig.Test."))
+	assert.Equal("admin.rig.test:8443", canonicalizeForwardedHost("admin.rig.test:8443"))
+	assert.Equal("admin.rig.test:8443", canonicalizeForwardedHost("admin.rig.test.:8443"))
+	assert.Equal("[::1]:8443", canonicalizeForwardedHost("[::1]:8443"))
+	assert.Equal("[2001:db8::1]:443", canonicalizeForwardedHost("[2001:db8::1]:443"))
+}
+
+func newForwardedRequest(host string) *http.Request {
+	req := newHTTPRequest("GET", "https://example.com/", "/")
+	req.Header.Set("X-Forwarded-Host", host)
+	req.Header.Set("Accept", "application/json")
+	return req
+}


### PR DESCRIPTION
## ELI5

Imagine the front door (Traefik) and the bouncer (this service) both check the name on a guest's invitation.

The invitation can say `admin.example.com` or `admin.example.com.` — that extra dot is a legal DNS spelling for the same place. The front door already knows they are the same person and lets them into the same room. The bouncer did not: it treated the dotted name as a stranger.

If you configured the bouncer as "let strangers in, but check ID for `admin.example.com`," the stranger with the extra dot walked past without ID. Traefik had already put them in the admin room.

**The fix:** before the bouncer reads the name, both the guest's invitation *and* the names on the bouncer's list are cleaned the same way (lowercase, strip one trailing dot, keep any port). Same person, same rule. If you wrote a custom `HostRegexp` yourself, we leave that alone.

Cookie / CSRF code still reads the original `X-Forwarded-Host` header. The only behavior change is that a dotted auth-host is treated as the same host, so we do not redirect it to itself.

NCN-116827

## Test plan
- [x] `go test ./internal/configuration/ ./internal/handlers/`
- [x] `go vet ./internal/configuration/ ./internal/handlers/`
- [ ] Review that cookie domain / CSRF host logic still reads the raw `X-Forwarded-Host` header